### PR TITLE
enable & fix map zooming

### DIFF
--- a/client/src/map/viewport.ts
+++ b/client/src/map/viewport.ts
@@ -13,6 +13,7 @@ export class Viewport {
         public mapHeight: number,
         private onUpdate: (event: Viewport) => void,
         private onClick: (e: MouseEvent, vp: Viewport) => void,
+        private onWheel: (e: WheelEvent) => void,
     ) {
         this.origin.copyFrom(origin)
 
@@ -28,7 +29,7 @@ export class Viewport {
         element.addEventListener('pointerleave', this.onPanEnd)
         element.addEventListener('pointerout', this.onPanEnd)
         element.addEventListener('contextmenu', this.onContextMenu)
-        element.addEventListener('wheel', this.onWheel)
+        element.addEventListener('wheel', this._onWheel)
     }
 
     private readonly observer;
@@ -41,7 +42,7 @@ export class Viewport {
         this.element.removeEventListener('pointerleave', this.onPanEnd)
         this.element.removeEventListener('pointerout', this.onPanEnd)
         this.element.removeEventListener('contextmenu', this.onContextMenu)
-        this.element.removeEventListener('wheel', this.onWheel)
+        this.element.removeEventListener('wheel', this._onWheel)
         this.observer.unobserve(this.element)
     }
 
@@ -67,9 +68,11 @@ export class Viewport {
         this.raiseOnUpdate()
     }
 
-    private onWheel = (e: MouseEvent) => {
+    private _onWheel = (e: WheelEvent) => {
         e.preventDefault()
         e.stopPropagation()
+
+        this.onWheel && this.onWheel(e);
     }
 
     private onContextMenu = (e: MouseEvent) => {

--- a/client/src/pages/game-page.tsx
+++ b/client/src/pages/game-page.tsx
@@ -70,18 +70,6 @@ function GameMapComponent({ selectedRegion, onRegionSelected }: GameMapProps) {
 
     return <Box sx={{ bgcolor: 'black', width: '100%', height: '100%' }}>
         <Box component={'canvas'} sx={{ width: '100%', height: '100%' }} ref={setCanvasRef} />
-        { (false && !!context.map) && <Box sx={{ position: 'absolute', display: 'flex', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'none' }}>
-            <Box sx={{ m: 2, flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-                <ButtonGroup sx={{ pointerEvents: 'all' }} orientation='vertical' size='small' color='inherit'>
-                    <Button variant='contained' onClick={() => context.map.zoomIn()}>
-                        <AddIcon />
-                    </Button>
-                    <Button variant='contained' onClick={() => context.map.zoomOut()}>
-                        <RemoveIcon />
-                    </Button>
-                </ButtonGroup>
-            </Box>
-        </Box> }
     </Box>
 }
 
@@ -524,6 +512,7 @@ export const MapTab = observer(() => {
     const { game } = useStore()
 
     const { battles } = game.world
+    const context = useMapContext()
 
     return <Box sx={{
         flex: 1,
@@ -555,10 +544,22 @@ export const MapTab = observer(() => {
                 minHeight: 0
             }}>
                 {/* Game Screens */}
+                <Box sx={{ position: 'absolute', display: 'flex', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'none' }}>
+                    <Box sx={{ m: 2, flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                        <ButtonGroup sx={{ pointerEvents: 'all' }} orientation='vertical' size='small' color='inherit'>
+                            <Button variant='contained' onClick={() => context.map.zoomIn()}>
+                                <AddIcon />
+                            </Button>
+                            <Button variant='contained' onClick={() => context.map.zoomOut()}>
+                                <RemoveIcon />
+                            </Button>
+                        </ButtonGroup>
+                    </Box>
+                </Box>
                 { !game.battlesVisible && <Box sx={{
                     position: 'absolute',
                     top: 0,
-                    left: 0,
+                    left: 70,
                     display: 'flex',
                     flexDirection: 'column',
                     justifyContent: 'flex-start',


### PR DESCRIPTION
Needed to remove the `updateVisibility() ` while zooming as with the current implementation it doesn't seem possible to hide only specific scene display objects, as we are rendering the same scene multiple times to provide the the map overlap horizontally.