### PR TITLE
fix for all order area to be clickable

### DIFF
--- a/client/src/components/order-editor.tsx
+++ b/client/src/components/order-editor.tsx
@@ -7,6 +7,8 @@ import { Typography, Box, BoxProps } from '@mui/material'
 import { Ruleset } from '../game'
 import { OrdersState, useStore } from '../store'
 import SimpleBar from 'simplebar-react'
+import {useEffect, useRef} from 'react';
+
 
 const OrdersEditor = styled(Editor)`
     min-height: 100%;
@@ -130,6 +132,13 @@ export const Orders = observer(({ readOnly, sx, ...props }: OrdersProps) => {
     const store = useStore()
     const game = store.game
     const ruleset = game.world.ruleset
+    const simpleBarRef = useRef(null);
+
+    useEffect(() => {
+        if (simpleBarRef.current) {
+            simpleBarRef.current.getContentElement().style.height = '100%';
+        }
+    }, [simpleBarRef])
 
     return <Box {...props} sx={{
         display: 'flex',
@@ -141,7 +150,7 @@ export const Orders = observer(({ readOnly, sx, ...props }: OrdersProps) => {
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
             <Typography variant='subtitle1'>Orders</Typography>
             <Box sx={{ flex: 1, border: 1, borderColor: 'divider', p: 1, mr: 1, minHeight: 0 }}>
-                <Box component={SimpleBar} sx={{ height: '100%' }} autoHide={false}>
+                <Box ref={simpleBarRef} component={SimpleBar} sx={{ height: '100%' }} autoHide={false}>
                     <OrdersEditor readOnly={readOnly} value={game.unitOrders ?? ''} onValueChange={game.setOrders} highlight={s => highlight(ruleset, s)} />
                 </Box>
             </Box>


### PR DESCRIPTION
it was quite annoying that orders area was not clickable in the all area, but only in the lines that contain orders.